### PR TITLE
Add CSP headers to unauthenticated controller

### DIFF
--- a/lib/shopify_app.rb
+++ b/lib/shopify_app.rb
@@ -38,6 +38,7 @@ module ShopifyApp
   # controller concerns
   require 'shopify_app/controller_concerns/csrf_protection'
   require 'shopify_app/controller_concerns/localization'
+  require 'shopify_app/controller_concerns/frame_ancestors'
   require 'shopify_app/controller_concerns/itp'
   require 'shopify_app/controller_concerns/login_protection'
   require 'shopify_app/controller_concerns/embedded_app'

--- a/lib/shopify_app/controller_concerns/embedded_app.rb
+++ b/lib/shopify_app/controller_concerns/embedded_app.rb
@@ -3,6 +3,8 @@ module ShopifyApp
   module EmbeddedApp
     extend ActiveSupport::Concern
 
+    include ShopifyApp::FrameAncestors
+
     included do
       if ShopifyApp.configuration.embedded_app?
         after_action(:set_esdk_headers)

--- a/lib/shopify_app/controller_concerns/frame_ancestors.rb
+++ b/lib/shopify_app/controller_concerns/frame_ancestors.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module ShopifyApp
+  module FrameAncestors
+    extend ActiveSupport::Concern
+
+    included do
+      content_security_policy do |policy|
+        policy.frame_ancestors(-> do
+          domain_host = current_shopify_domain || "*.myshopify.com"
+          "https://#{domain_host} https://admin.shopify.com;"
+        end)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Merge [#1474](https://github.com/Shopify/shopify_app/pull/1474) to set CSP frame-ancestors directives.